### PR TITLE
Add Laravel 10 support

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -12,13 +12,20 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        os: [ubuntu-latest, windows-latest]
-        php: [8.0]
-        laravel: [8.*]
+        os: [ubuntu-latest]
+        php: [8.0, 8.1, 8.2]
+        laravel: [8.*, 9.*, 10.*]
         stability: [prefer-lowest, prefer-stable]
         include:
           - laravel: 8.*
             testbench: ^6.23
+          - laravel: 9.*
+            testbench: ^7.0
+          - laravel: 10.*
+            testbench: ^8.0
+        exclude:
+          - laravel: 10.*
+            php: 8.0
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}
 

--- a/composer.json
+++ b/composer.json
@@ -18,18 +18,18 @@
     "require": {
         "php": "^8.0",
         "spatie/laravel-package-tools": "^1.9.2",
-        "illuminate/contracts": "^8.73|^9.0"
+        "illuminate/contracts": "^8.73|^9.0|^10.0"
     },
     "require-dev": {
-        "nunomaduro/collision": "^5.10|^6.0",
+        "nunomaduro/collision": "^5.10|^6.0|^7.0",
         "nunomaduro/larastan": "^1.0",
-        "orchestra/testbench": "^6.22",
+        "orchestra/testbench": "^6.22|^7.0|^8.0",
         "pestphp/pest": "^1.21",
         "pestphp/pest-plugin-laravel": "^1.1",
         "phpstan/extension-installer": "^1.1",
         "phpstan/phpstan-deprecation-rules": "^1.0",
         "phpstan/phpstan-phpunit": "^1.0",
-        "phpunit/phpunit": "^9.5",
+        "phpunit/phpunit": "^9.5|^10.0",
         "spatie/laravel-ray": "^1.26"
     },
     "autoload": {
@@ -49,7 +49,11 @@
         "test-coverage": "vendor/bin/pest --coverage"
     },
     "config": {
-        "sort-packages": true
+        "sort-packages": true,
+        "allow-plugins": {
+            "pestphp/pest-plugin": true,
+            "phpstan/extension-installer": true
+        }
     },
     "extra": {
         "laravel": {


### PR DESCRIPTION
This PR adds support for Laravel 10. I have also updated the GA for the tests, but then I discovered that there were not yet any tests. So just in case you ever decided to add tests, the GA is ready for it 😀

Thanks!